### PR TITLE
Use navigate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,9 @@ localizeService.translateRoute('/'); // -> e.g. '/en'
 localizeService.translateRoute('/about'); // -> '/de/uber' (e.g. for German language)
 localizeService.translateRoute('about'); // -> 'uber' (e.g. for German language)
 ```
-- `changeLanguage(lang: string)`: Translates current url to given language and changes the application's language
+- `changeLanguage(lang: string, extras?: NavigationExtras, useNavigateMethod?: boolean)`: Translates current url to given language and changes the application's language.
+`extras` will be passed down to Angular Router navigation methods.
+`userNavigateMethod` tells localize-router to use `navigate` rather than `navigateByUrl` method.  
 For german language and route defined as `:lang/users/:user_name/profile`
 ```
 yoursite.com/en/users/John%20Doe/profile -> yoursite.com/de/benutzer/John%20Doe/profil

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test-watch": "karma start --singleRun=false --autoWatch=true",
     "commit": "npm run prepublish && npm test",
     "prepublish": "ngc && npm run build",
+    "prepare": "ngc && npm run build",
     "build": "webpack"
   },
   "repository": {

--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -35,13 +35,20 @@ export class LocalizeRouterService {
    * Change language and navigate to translated route
    * @param lang
    * @param extras
+   * @param useNavigateMethod
    */
-  changeLanguage(lang: string, extras?: NavigationExtras): void {
+  changeLanguage(lang: string, extras?: NavigationExtras, useNavigateMethod?: boolean): void {
     if (lang !== this.parser.currentLang) {
       let rootSnapshot: ActivatedRouteSnapshot = this.router.routerState.snapshot.root;
 
       this.parser.translateRoutes(lang).subscribe(() => {
-        this.router.navigateByUrl(this.traverseRouteSnapshot(rootSnapshot), extras);
+        const url = this.traverseRouteSnapshot(rootSnapshot);
+        
+        if (useNavigateMethod) {
+          this.router.navigate([url], extras);
+        } else {
+          this.router.navigateByUrl(url, extras);
+        }
       });
     }
   }


### PR DESCRIPTION
Added parameter `useNavigateMethod` to `changeLanguage` that tells localize-router to use `navigate` rather than `navigateByUrl`.
Why:
- App in router state `/en/about?page=company`
- Change language
- App in router state `/ru/about` without previous query params

That's because `navigateByUrl` doesn't respect `queryParams` in `extras`. Using `navigate` solves this issue. 

Also i've updated documentation for `changeLanguage` method.