### PR TITLE
getLocationLang doesn't use alwaysSetPrefix

### DIFF
--- a/src/localize-router.parser.ts
+++ b/src/localize-router.parser.ts
@@ -237,9 +237,6 @@ export abstract class LocalizeParser {
     if (pathSlices.length && this.locales.indexOf(pathSlices[0]) !== -1) {
       return pathSlices[0];
     }
-    if (!this.settings.alwaysSetPrefix) {
-      return this.defaultLang;
-    }
     return null;
   }
 

--- a/src/localize-router.parser.ts
+++ b/src/localize-router.parser.ts
@@ -237,6 +237,9 @@ export abstract class LocalizeParser {
     if (pathSlices.length && this.locales.indexOf(pathSlices[0]) !== -1) {
       return pathSlices[0];
     }
+    if (!this.settings.alwaysSetPrefix) {
+      return this.defaultLang;
+    }
     return null;
   }
 

--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -150,8 +150,8 @@ export class LocalizeRouterService {
    */
   private _routeChanged(): (eventPair: [NavigationStart, NavigationStart]) => void {
     return ([previousEvent, currentEvent]: [NavigationStart, NavigationStart]) => {
-      const previousLang = this.parser.getLocationLang(previousEvent.url);
-      const currentLang = this.parser.getLocationLang(currentEvent.url);
+      const previousLang = this.parser.getLocationLang(previousEvent.url) || this.parser.defaultLang;
+      const currentLang = this.parser.getLocationLang(currentEvent.url) || this.parser.defaultLang;
 
       if (currentLang !== previousLang) {
         this.parser.translateRoutes(currentLang).subscribe(() => {


### PR DESCRIPTION
When url has no language as the first part getLocationLang fails and returns null which breaks routeChanged event handler in LocalizeRouterService which goes on to break every route since it can't load null language.