### PR TITLE
fix: angular 5 element life-cycle not triggered correctly due to pipe

### DIFF
--- a/src/localize-router.parser.ts
+++ b/src/localize-router.parser.ts
@@ -4,8 +4,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 import { Location } from '@angular/common';
-import 'rxjs/add/observable/forkJoin';
-import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/toPromise';
 import { CacheMechanism, LocalizeRouterSettings } from './localize-router.config';
 

--- a/src/localize-router.pipe.ts
+++ b/src/localize-router.pipe.ts
@@ -1,7 +1,6 @@
 import { PipeTransform, Pipe, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { LocalizeRouterService } from './localize-router.service';
 import { Subscription } from 'rxjs/Subscription';
-import { equals } from './util';
 
 @Pipe({
   name: 'localize',
@@ -35,7 +34,7 @@ export class LocalizeRouterPipe implements PipeTransform, OnDestroy {
     if (!query || query.length === 0 || !this.localize.parser.currentLang) {
       return query;
     }
-    if (!this.markForTransform && equals(query, this.lastKey) && this.lastLanguage === this.localize.parser.currentLang) {
+    if (!this.markForTransform && query === this.lastKey && this.lastLanguage === this.localize.parser.currentLang) {
       return this.value;
     }
     this.lastKey = query;

--- a/src/localize-router.pipe.ts
+++ b/src/localize-router.pipe.ts
@@ -48,9 +48,7 @@ export class LocalizeRouterPipe implements PipeTransform, OnDestroy {
   }
 
   ngOnDestroy() {
-    if (this.changes$$) {
       this.changes$$.unsubscribe();
-    }
   }
 
 }

--- a/src/localize-router.pipe.ts
+++ b/src/localize-router.pipe.ts
@@ -1,21 +1,20 @@
-import { PipeTransform, Pipe, Injectable, ChangeDetectorRef } from '@angular/core';
+import { PipeTransform, Pipe, Injectable, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { LocalizeRouterService } from './localize-router.service';
 import { Subscription } from 'rxjs/Subscription';
 import 'rxjs/add/observable/forkJoin';
 import { equals } from './util';
-
-const VIEW_DESTROYED_STATE = 128;
 
 @Injectable()
 @Pipe({
   name: 'localize',
   pure: false // required to update the value when the promise is resolved
 })
-export class LocalizeRouterPipe implements PipeTransform {
+export class LocalizeRouterPipe implements PipeTransform, OnDestroy {
+  private markForTransform = true;
   private value: string | any[] = '';
   private lastKey: string | any[];
   private lastLanguage: string;
-  private subscription: Subscription;
+  private changes$$: Subscription;
 
   /**
    * CTOR
@@ -23,8 +22,9 @@ export class LocalizeRouterPipe implements PipeTransform {
    * @param _ref
    */
   constructor(private localize: LocalizeRouterService, private _ref: ChangeDetectorRef) {
-    this.subscription = this.localize.routerEvents.subscribe(() => {
-      this.transform(this.lastKey);
+    this.changes$$ = this.localize.routerEvents.subscribe(() => {
+      this.markForTransform = true;
+      this._ref.markForCheck();
     });
   }
 
@@ -37,7 +37,7 @@ export class LocalizeRouterPipe implements PipeTransform {
     if (!query || query.length === 0 || !this.localize.parser.currentLang) {
       return query;
     }
-    if (equals(query, this.lastKey) && equals(this.lastLanguage, this.localize.parser.currentLang)) {
+    if (!this.markForTransform && equals(query, this.lastKey) && this.lastLanguage === this.localize.parser.currentLang) {
       return this.value;
     }
     this.lastKey = query;
@@ -46,11 +46,14 @@ export class LocalizeRouterPipe implements PipeTransform {
     /** translate key and update values */
     this.value = this.localize.translateRoute(query);
     this.lastKey = query;
-    // if view is already destroyed, ignore firing change detection
-    if ((<any> this._ref)._view.state & VIEW_DESTROYED_STATE) {
-      return this.value;
-    }
-    this._ref.detectChanges();
+    this.markForTransform = false;
     return this.value;
   }
+
+  ngOnDestroy() {
+    if (this.changes$$) {
+      this.changes$$.unsubscribe();
+    }
+  }
+
 }

--- a/src/localize-router.pipe.ts
+++ b/src/localize-router.pipe.ts
@@ -1,13 +1,12 @@
-import { PipeTransform, Pipe, Injectable, ChangeDetectorRef, OnDestroy } from '@angular/core';
+import { PipeTransform, Pipe, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { LocalizeRouterService } from './localize-router.service';
 import { Subscription } from 'rxjs/Subscription';
 import 'rxjs/add/observable/forkJoin';
 import { equals } from './util';
 
-@Injectable()
 @Pipe({
   name: 'localize',
-  pure: false // required to update the value when the promise is resolved
+  pure: false // required to become stateful and keep value updated on event changes.
 })
 export class LocalizeRouterPipe implements PipeTransform, OnDestroy {
   private markForTransform = true;

--- a/src/localize-router.pipe.ts
+++ b/src/localize-router.pipe.ts
@@ -1,7 +1,6 @@
 import { PipeTransform, Pipe, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { LocalizeRouterService } from './localize-router.service';
 import { Subscription } from 'rxjs/Subscription';
-import 'rxjs/add/observable/forkJoin';
 import { equals } from './util';
 
 @Pipe({

--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Router, NavigationStart, ActivatedRouteSnapshot, NavigationExtras, UrlSegment } from '@angular/router';
 import { Subject } from 'rxjs/Subject';
-import 'rxjs/add/observable/forkJoin';
-import 'rxjs/add/operator/toPromise';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/pairwise';
 

--- a/tests/localize-router.pipe.spec.ts
+++ b/tests/localize-router.pipe.spec.ts
@@ -5,8 +5,6 @@ import { getTestBed, TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs/Subject';
 
 class FakeChangeDetectorRef extends ChangeDetectorRef {
-  _view = { state: 0 };
-
   markForCheck(): void {
   }
 
@@ -87,79 +85,79 @@ describe('LocalizeRouterPipe', () => {
 
   it('should translate a complex segment route if it changed', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform(['/path', null, 'my', 5]);
-    ref.detectChanges.calls.reset();
+    ref.markForCheck.calls.reset();
 
     localizePipe.transform(['/path', 4, 'my', 5]);
-    expect(ref.detectChanges).toHaveBeenCalled();
+    expect(ref.markForCheck).toHaveBeenCalled();
   });
 
   it('should not translate a complex segment route if it`s not changed', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform(['/path', 4, 'my', 5]);
-    ref.detectChanges.calls.reset();
+    ref.markForCheck.calls.reset();
 
     localizePipe.transform(['/path', 4, 'my', 5]);
-    expect(ref.detectChanges).not.toHaveBeenCalled();
+    expect(ref.markForCheck).not.toHaveBeenCalled();
   });
 
   it('should call markForChanges when it translates a string', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform('route');
-    expect(ref.detectChanges).toHaveBeenCalled();
+    expect(ref.markForCheck).toHaveBeenCalled();
   });
 
   it('should not call markForChanges when query is not string', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform(null);
-    expect(ref.detectChanges).not.toHaveBeenCalled();
+    expect(ref.markForCheck).not.toHaveBeenCalled();
   });
 
   it('should not call markForChanges when query is empty string', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform('');
-    expect(ref.detectChanges).not.toHaveBeenCalled();
+    expect(ref.markForCheck).not.toHaveBeenCalled();
   });
 
   it('should not call markForChanges when no language selected', () => {
     localize.parser.currentLang = null;
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform('route');
-    expect(ref.detectChanges).not.toHaveBeenCalled();
+    expect(ref.markForCheck).not.toHaveBeenCalled();
   });
 
   it('should not call markForChanges if same route already translated', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
     localizePipe.transform('route');
     localizePipe.transform('route');
-    expect(ref.detectChanges.calls.count()).toEqual(1);
+    expect(ref.markForCheck.calls.count()).toEqual(1);
   });
 
   it('should subscribe to service`s routerEvents', () => {
     let query = 'MY_TEXT';
     localize.parser.currentLang = 'en';
     spyOn(localizePipe, 'transform').and.callThrough();
-    spyOn(ref, 'detectChanges').and.callThrough();
+    spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform(query);
-    ref.detectChanges.calls.reset();
+    ref.markForCheck.calls.reset();
     (<any>localizePipe.transform)['calls'].reset();
 
     localize.parser.currentLang = 'de';
     localize.routerEvents.next('de');
     expect(localizePipe.transform).toHaveBeenCalled();
-    expect(ref.detectChanges).toHaveBeenCalled();
+    expect(ref.markForCheck).toHaveBeenCalled();
   });
 });

--- a/tests/localize-router.pipe.spec.ts
+++ b/tests/localize-router.pipe.spec.ts
@@ -85,75 +85,75 @@ describe('LocalizeRouterPipe', () => {
 
   it('should translate a complex segment route if it changed', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'markForCheck').and.callThrough();
+    const translateRouteSpy = spyOn(localize, 'translateRoute').and.callThrough();
 
     localizePipe.transform(['/path', null, 'my', 5]);
-    ref.markForCheck.calls.reset();
+    translateRouteSpy.calls.reset();
 
     localizePipe.transform(['/path', 4, 'my', 5]);
-    expect(ref.markForCheck).toHaveBeenCalled();
+    expect(translateRouteSpy).toHaveBeenCalled();
   });
 
   it('should not translate a complex segment route if it`s not changed', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'markForCheck').and.callThrough();
+    const translateRouteSpy = spyOn(localize, 'translateRoute').and.callThrough();
 
     localizePipe.transform(['/path', 4, 'my', 5]);
-    ref.markForCheck.calls.reset();
+    translateRouteSpy.calls.reset();
 
     localizePipe.transform(['/path', 4, 'my', 5]);
-    expect(ref.markForCheck).not.toHaveBeenCalled();
+    expect(translateRouteSpy).not.toHaveBeenCalled();
   });
 
-  it('should call markForChanges when it translates a string', () => {
+  it('should not translate if same route already translated', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'markForCheck').and.callThrough();
+    const translateRouteSpy = spyOn(localize, 'translateRoute').and.callThrough();
+    localizePipe.transform('route');
+    localizePipe.transform('route');
+    expect(translateRouteSpy.calls.count()).toEqual(1);
+  });
+
+  it('should translate when query is a string', () => {
+    localize.parser.currentLang = 'en';
+    const translateRouteSpy = spyOn(localize, 'translateRoute').and.callThrough();
 
     localizePipe.transform('route');
-    expect(ref.markForCheck).toHaveBeenCalled();
+    expect(translateRouteSpy).toHaveBeenCalled();
   });
 
-  it('should not call markForChanges when query is not string', () => {
+  it('should not translate when query is null', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'markForCheck').and.callThrough();
+    const translateRouteSpy = spyOn(localize, 'translateRoute').and.callThrough();
 
     localizePipe.transform(null);
-    expect(ref.markForCheck).not.toHaveBeenCalled();
+    expect(translateRouteSpy).not.toHaveBeenCalled();
   });
 
-  it('should not call markForChanges when query is empty string', () => {
+  it('should not translate when query is empty string', () => {
     localize.parser.currentLang = 'en';
-    spyOn(ref, 'markForCheck').and.callThrough();
+    const translateRouteSpy = spyOn(localize, 'translateRoute').and.callThrough();
 
     localizePipe.transform('');
-    expect(ref.markForCheck).not.toHaveBeenCalled();
+    expect(translateRouteSpy).not.toHaveBeenCalled();
   });
 
-  it('should not call markForChanges when no language selected', () => {
+  it('should not translate when no language selected', () => {
     localize.parser.currentLang = null;
-    spyOn(ref, 'markForCheck').and.callThrough();
+    const translateRouteSpy = spyOn(localize, 'translateRoute').and.callThrough();
 
     localizePipe.transform('route');
-    expect(ref.markForCheck).not.toHaveBeenCalled();
-  });
-
-  it('should not call markForChanges if same route already translated', () => {
-    localize.parser.currentLang = 'en';
-    spyOn(ref, 'markForCheck').and.callThrough();
-    localizePipe.transform('route');
-    localizePipe.transform('route');
-    expect(ref.markForCheck.calls.count()).toEqual(1);
+    expect(translateRouteSpy).not.toHaveBeenCalled();
   });
 
   it('should subscribe to service`s routerEvents', () => {
     let query = 'MY_TEXT';
     localize.parser.currentLang = 'en';
-    spyOn(localizePipe, 'transform').and.callThrough();
+    const transmformSpy = spyOn(localizePipe, 'transform').and.callThrough();
     spyOn(ref, 'markForCheck').and.callThrough();
 
     localizePipe.transform(query);
     ref.markForCheck.calls.reset();
-    (<any>localizePipe.transform)['calls'].reset();
+    transmformSpy.calls.reset();
 
     localize.parser.currentLang = 'de';
     localize.routerEvents.next('de');


### PR DESCRIPTION
We are currently updating to angular 5, and making use of this library.
After the update, we have some components broken, and after some debugging I've noticed it was being caused by the `localize` pipe of this library, its caused with the `ref.detectChanges`, still, the reason why its still bit weird (might be an issue with angular itself tbh).

### Issue
Basically, we have a super simple button directive (simply adds some classes on an element) on init, and once using the directive in conjunction with the localize pipe it's causing the `ngOnInit` to never be invoked.

This PR fixes that and also some other refactoring/improvements.

P.S. I cannot get tests to work I'm getting q the following error:
```
HeadlessChrome 0.0.0 (Windows 10 0.0.0) ERROR
  Uncaught ReferenceError: core_2 is not defined
  at webpack:///src/localize-router.parser.ts:2:0 <- config/spec-bundle.js:23565
```

This is one of the last few issues which are blocking us from updating to angular 5, would highly appreciate if you can look into it a bit urgently. Thanks.

using `localize-router ` version `1.0.0-rc.3`