### PR TITLE
(docs): Fix example code by importing Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ In order to use Http loader for config files, you must include `localize-router-
 ```ts
 import {BrowserModule} from "@angular/platform-browser";
 import {NgModule} from '@angular/core';
+import {Location} from '@angular/common';
 import {HttpClientModule, HttpClient} from '@angular/common/http';
 import {TranslateModule} from '@ngx-translate/core';
 import {LocalizeRouterModule} from 'localize-router';


### PR DESCRIPTION
Fix example code by importing Location from @angular/common