### PR TITLE
(fix) Missing not found value for lazy loaded modules

### DIFF
--- a/src/localize-router-config-loader.ts
+++ b/src/localize-router-config-loader.ts
@@ -28,8 +28,8 @@ export class LocalizeRouterConfigLoader extends SystemJsNgModuleLoader {
           const module = factory.create(parentInjector);
           const getMethod = module.injector.get.bind(module.injector);
 
-          module.injector['get'] = (token: any) => {
-            const getResult = getMethod(token);
+          module.injector['get'] = (token: any, notFoundValue: any) => {
+            const getResult = getMethod(token, notFoundValue);
 
             if (token === ROUTES) {
               // translate lazy routes


### PR DESCRIPTION
The notFoundValue depends on deps.flag and must be included in the getMethod.

Fix https://github.com/Greentube/localize-router/issues/104