### PR TITLE
Support empty paths

### DIFF
--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -87,9 +87,12 @@ export class LocalizeRouterService {
    * @returns {string}
    */
   private traverseRouteSnapshot(snapshot: ActivatedRouteSnapshot): string {
-    if (snapshot.firstChild && snapshot.firstChild.routeConfig && snapshot.firstChild.routeConfig.path) {
+    if (snapshot.firstChild && snapshot.firstChild.routeConfig) {
       if (snapshot.firstChild.routeConfig.path !== '**') {
-        return this.parseSegmentValue(snapshot) + '/' + this.traverseRouteSnapshot(snapshot.firstChild);
+        if (snapshot.firstChild.routeConfig.path) {
+          return this.parseSegmentValue(snapshot) + '/' + this.traverseRouteSnapshot(snapshot.firstChild);
+        }
+        return this.parseSegmentValue(snapshot) + this.traverseRouteSnapshot(snapshot.firstChild);
       } else {
         return this.parseSegmentValue(snapshot.firstChild);
       }


### PR DESCRIPTION
It is now possible to use empty paths (path: ''). This is needed to have wrapper paths.