### PR TITLE
fix: for #115

### DIFF
--- a/src/localize-router.parser.ts
+++ b/src/localize-router.parser.ts
@@ -1,14 +1,12 @@
-import { Routes, Route } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
-import { Observable } from 'rxjs/Observable';
-import { Observer } from 'rxjs/Observer';
 import { Location } from '@angular/common';
+import { Inject } from '@angular/core';
+import { Route, Routes } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/toPromise';
 import { CacheMechanism, LocalizeRouterSettings } from './localize-router.config';
-import { Inject } from '@angular/core';
 
 const COOKIE_EXPIRY = 30; // 1 month
 
@@ -111,7 +109,7 @@ export abstract class LocalizeParser {
 
     /** translate routes */
     const res = this.translateRoutes(selectedLanguage);
-    return res.toPromise();
+    return res;
   }
 
   initChildRoutes(routes: Routes) {
@@ -124,7 +122,7 @@ export abstract class LocalizeParser {
    * @param language
    * @returns {Promise<any>}
    */
-  translateRoutes(language: string): Observable<any> {
+  translateRoutes(language: string): Promise<any> {
       this._cachedLang = language;
       if (this._languageRoute) {
         this._languageRoute.path = language;
@@ -146,7 +144,7 @@ export abstract class LocalizeParser {
           this._translateRouteTree(this.routes);
         }
 
-      });
+      }).toPromise();
   }
 
   /**

--- a/src/localize-router.parser.ts
+++ b/src/localize-router.parser.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 import { Location } from '@angular/common';
 import 'rxjs/add/observable/forkJoin';
+import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/share';
 import 'rxjs/add/operator/toPromise';
 import { CacheMechanism, LocalizeRouterSettings } from './localize-router.config';
@@ -124,13 +125,12 @@ export abstract class LocalizeParser {
    * @returns {Promise<any>}
    */
   translateRoutes(language: string): Observable<any> {
-    return new Observable<any>((observer: Observer<any>) => {
       this._cachedLang = language;
       if (this._languageRoute) {
         this._languageRoute.path = language;
       }
 
-      this.translate.use(language).subscribe((translations: any) => {
+      return this.translate.use(language).map((translations: any) => {
         this._translationObject = translations;
         this.currentLang = language;
 
@@ -146,10 +146,7 @@ export abstract class LocalizeParser {
           this._translateRouteTree(this.routes);
         }
 
-        observer.next(void 0);
-        observer.complete();
       });
-    });
   }
 
   /**
@@ -352,7 +349,7 @@ export abstract class LocalizeParser {
       return key;
     }
     let res = this.translate.getParsedResult(this._translationObject, this.prefix + key);
-    return res || key;
+    return typeof res === 'string' ? res : key;
   }
 }
 

--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -1,14 +1,14 @@
 import { Inject } from '@angular/core';
-import { Router, NavigationStart, ActivatedRouteSnapshot, NavigationExtras, UrlSegment } from '@angular/router';
-import { Subject } from 'rxjs/Subject';
+import { ActivatedRouteSnapshot, NavigationExtras, NavigationStart, Router, UrlSegment } from '@angular/router';
 import 'rxjs/add/observable/forkJoin';
-import 'rxjs/add/operator/toPromise';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/pairwise';
-
-import { LocalizeParser } from './localize-router.parser';
+import 'rxjs/add/operator/toPromise';
+import { Subject } from 'rxjs/Subject';
 import { LocalizeRouterSettings } from './localize-router.config';
+import { LocalizeParser } from './localize-router.parser';
+
 
 /**
  * Localization service
@@ -49,7 +49,7 @@ export class LocalizeRouterService {
     if (lang !== this.parser.currentLang) {
       let rootSnapshot: ActivatedRouteSnapshot = this.router.routerState.snapshot.root;
 
-      this.parser.translateRoutes(lang).subscribe(() => {
+      this.parser.translateRoutes(lang).then(_ => {
         let url = this.traverseRouteSnapshot(rootSnapshot);
 
         if (!this.settings.alwaysSetPrefix) {
@@ -155,9 +155,9 @@ export class LocalizeRouterService {
       const currentLang = this.parser.getLocationLang(currentEvent.url) || this.parser.defaultLang;
 
       if (currentLang !== previousLang) {
+        this.router.resetConfig(this.parser.routes);
         this.parser.translateRoutes(currentLang)
-        .do(_ => this.router.resetConfig(this.parser.routes))
-        .subscribe(() => {
+        .then(_ => {
           // Fire route change event
           this.router.resetConfig(this.parser.routes);
           this.routerEvents.next(currentLang);

--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -3,6 +3,7 @@ import { Router, NavigationStart, ActivatedRouteSnapshot, NavigationExtras, UrlS
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/observable/forkJoin';
 import 'rxjs/add/operator/toPromise';
+import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/pairwise';
 
@@ -72,6 +73,7 @@ export class LocalizeRouterService {
           url = urlSegments.join('/');
         }
 
+        this.router.resetConfig(this.parser.routes);
         if (useNavigateMethod) {
           this.router.navigate([url], extras);
         } else {
@@ -153,8 +155,11 @@ export class LocalizeRouterService {
       const currentLang = this.parser.getLocationLang(currentEvent.url) || this.parser.defaultLang;
 
       if (currentLang !== previousLang) {
-        this.parser.translateRoutes(currentLang).subscribe(() => {
+        this.parser.translateRoutes(currentLang)
+        .do(_ => this.router.resetConfig(this.parser.routes))
+        .subscribe(() => {
           // Fire route change event
+          this.router.resetConfig(this.parser.routes);
           this.routerEvents.next(currentLang);
         });
       }


### PR DESCRIPTION
Per @Hezard 's [solution](https://github.com/Greentube/localize-router/issues/115#issuecomment-375491922)
fixs for 5.2.7+ and 6
Also fixed a case where `translateText` may return a parsed object rather than a string.