### PR TITLE
fix: Service does not add empty prefix

### DIFF
--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -158,8 +158,17 @@ export class LocalizeRouterService {
       return path;
     }
     if (typeof path === 'string') {
-      const url = this.parser.translateRoute(path);
-      return !path.indexOf('/') ? `/${this.parser.urlPrefix}${url}` : url;
+      const translatedUrl = this.parser.translateRoute(path);
+      let url = translatedUrl;
+      
+      if (!path.indexOf('/')) {
+        const prefix = this.parser.urlPrefix;
+        if (prefix !== '') {
+          url = '/' + prefix + translatedUrl;
+        }
+      }
+
+      return url;
     }
     // it's an array
     let result: any[] = [];
@@ -167,7 +176,13 @@ export class LocalizeRouterService {
       if (typeof segment === 'string') {
         const res = this.parser.translateRoute(segment);
         if (!index && !segment.indexOf('/')) {
-          result.push(`/${this.parser.urlPrefix}${res}`);
+          const prefix = this.parser.urlPrefix;
+          let translatedPath = res;
+
+          if (prefix !== '') {
+            translatedPath = `/${this.parser.urlPrefix}${res}`
+          }
+          result.push(translatedPath);
         } else {
           result.push(res);
         }

--- a/tests/localize-router.service.spec.ts
+++ b/tests/localize-router.service.spec.ts
@@ -136,6 +136,33 @@ describe('LocalizeRouterService', () => {
     expect(parser.translateRoute).toHaveBeenCalledWith('about');
   });
 
+  it('should not append empty prefix', () => {
+    const settings = {
+      alwaysSetPrefix: false
+    } as any
+
+    localizeRouterService = new LocalizeRouterService(parser, settings, router);
+    parser.currentLang = 'en';
+    parser.defaultLang = 'en';
+    parser.locales = ['de', 'en'];
+    (<any>parser).settings = settings
+
+    spyOn(parser, 'translateRoute').and.callThrough();
+    
+    let res = localizeRouterService.translateRoute(['/my/path', 123, 'about']);
+    expect(res[0]).toEqual('/my/path');
+
+    res = localizeRouterService.translateRoute('/my/path');
+    expect(res).toEqual('/my/path');
+    
+    parser.currentLang = 'de'
+    res = localizeRouterService.translateRoute(['/my/path', 123, 'about']);
+    expect(res[0]).toEqual('/de/my/path');
+
+    res = localizeRouterService.translateRoute('/my/path');
+    expect(res).toEqual('/de/my/path');
+  })
+
   it('should translate routes if language had changed on route event', () => {
     localizeRouterService = new LocalizeRouterService(parser, settings, router);
     localizeRouterService.init();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently using pipe with alwaysSetPrefix option set to false, results in links in a default language, being prepended with double slashes (//) ie.
`en: /my/path -> //my/path`
`de: /my/path -> /de/my/path`
This behaviour cannot be seen when using a pipe to translate for routerLink, but is visible when the pipe is used to show a path in template interpolation

Issue Number: N/A

## What is the new behavior?
If the parser returns empty string as prefix, it is not added to path

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
