### PR TITLE
fix issue with changeLanguage when route parameters are used

### DIFF
--- a/src/localize-router.service.ts
+++ b/src/localize-router.service.ts
@@ -81,7 +81,7 @@ export class LocalizeRouterService {
    * Traverses through the tree to assemble new translated url
    * @param snapshot
    * @param isRoot
-   * @returns {string}
+   * @returns {string[]}
    */
   private traverseSnapshot(
     snapshot: ActivatedRouteSnapshot,
@@ -99,7 +99,7 @@ export class LocalizeRouterService {
       }
     }
 
-    const urlPart = this.parseSegmentValue(snapshot);
+    const urlParts = this.parseSegmentValue(snapshot);
 
     const outletChildren = snapshot.children
       .filter(child => child.outlet !== PRIMARY_OUTLET);
@@ -115,8 +115,7 @@ export class LocalizeRouterService {
     const primaryChild = snapshot.children.find(child => child.outlet === PRIMARY_OUTLET);
 
     return [
-      urlPart,
-      ...Object.keys(snapshot.params).length ? [snapshot.params] : [],
+      ...urlParts,
       ...outletChildren.length ? [outlets] : [],
       ...primaryChild ? this.traverseSnapshot(primaryChild) : []
     ];
@@ -125,25 +124,24 @@ export class LocalizeRouterService {
   /**
    * Extracts new segment value based on routeConfig and url
    * @param snapshot
-   * @returns {string}
+   * @returns {string[]}
    */
-  private parseSegmentValue(snapshot: ActivatedRouteSnapshot): string {
+  private parseSegmentValue(snapshot: ActivatedRouteSnapshot): string[] {
     if (snapshot.routeConfig) {
       if (snapshot.routeConfig.path === '**') {
-        return this.parser.translateRoute(snapshot.url
+        return snapshot.url
           .filter((segment: UrlSegment) => segment.path)
-          .map((segment: UrlSegment) => segment.path)
-          .join('/'));
+          .map((segment: UrlSegment) => this.parser.translateRoute(segment.path));
       } else if (snapshot.routeConfig.data) {
         const subPathSegments = snapshot.routeConfig.data.localizeRouter.path.split('/');
         return subPathSegments
           .map((s: string, i: number) => s.indexOf(':') === 0 ?
             snapshot.url[i].path :
-            this.parser.translateRoute(s))
-          .join('/');
+            this.parser.translateRoute(s)
+          );
       }
     }
-    return '';
+    return [''];
   }
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #151 

(copied from issue) Using angular 7+ if a route as parameters, for example :name or :id, this method on this line "...Object.keys(snapshot.params).length ? [snapshot.params] : []," will add to the route the following ";name=valueofthename" or ";id=valueoftheid". There is another problem on the line above on the urlPart this urlPart I think needs to be splited by "/" otherwise if my route is something like "person/:name" the the result of calling the method changeLanguage that calls the traverseSnapshot will result in something like "lang/person%2Fvalueofthename;name=valueofthename".

## What is the new behavior?
It will correctly assemble the route when changing the language and using route params.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is now an issue for over 3 months and nothing happened. I'm using this fix in production for this time and nothing broke. I think we are save to merge this PR without adding new tests.

Credits to cywolf (https://github.com/cywolf) for the fix!